### PR TITLE
Use UMD

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,3 @@
+[*.js]
+indent_style = tab
+indent_size = 4

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,3 +1,3 @@
-[*.js]
+[*]
 indent_style = tab
 indent_size = 4

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,7 +1,9 @@
 {
 	"extends": "wikimedia",
 	"env": {
-		"browser": true
+		"browser": true,
+		"commonjs": true,
+		"amd": true
 	},
 	"globals": {
 		"RangeFix": false

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "rangefix",
-	"version": "0.2.3",
+	"version": "0.2.4",
 	"description": "Workaround for browser bugs in Range.prototype.getClientRects and Range.prototype.getBoundingClientRect.",
 	"license": "MIT",
 	"author": "Ed Sanders",

--- a/rangefix.js
+++ b/rangefix.js
@@ -262,7 +262,5 @@
 		return boundingRect;
 	};
 
-	// Expose
-	window.RangeFix = rangeFix;
-
+	return rangeFix;
 } ) );

--- a/rangefix.js
+++ b/rangefix.js
@@ -5,7 +5,18 @@
  * Copyright 2014-17 Ed Sanders.
  * Released under the MIT license
  */
-( function () {
+( function ( root, factory ) {
+	if ( typeof define === 'function' && define.amd ) {
+		// AMD. Register as an anonymous module.
+		define( factory );
+	} else if ( typeof exports === 'object' && typeof exports.nodeName !== 'string' ) {
+		// CommonJS
+		module.exports = factory();
+	} else {
+		// Browser globals
+		root.RangeFix = factory();
+	}
+}( this, function () {
 
 	var broken,
 		rangeFix = {};
@@ -254,4 +265,4 @@
 	// Expose
 	window.RangeFix = rangeFix;
 
-}() );
+} ) );


### PR DESCRIPTION
We are using [some code](https://github.com/guardian/frontend/blob/master/static/src/javascripts-legacy/lib/client-rects.js) from this workaround in our application, but I would like to instead install it as a dependency.

This change allows consumers to import the `RangeFix` object into their projects as a CommonJS or AMD dependency, while still exposing it as a global for the browser.

As a small side effect, I've also added an `.editorconfig` to make it easier for other authors to work on this project. Let me know if you'd like it gone 😄 

Any other suggestions, please let me know