### PR TITLE
UMD improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,25 +20,21 @@ Usage
 **CommonJS**
 
 ```javascript
-const RangeFix = require('rangefix');
+var RangeFix = require( 'rangefix' );
 ```
 
 **AMD**
 
 ```javascript
-define(['rangefix'], function(Rangefix) {
-  // ...
-});
+define( [ 'rangefix' ], function( Rangefix ) {
+	// ...
+} );
 ```
 
 **Browser global**
 
 ```html
 <script src="path/to/rangefix.js"></script>
-<script>
-  // RangeFix will be available on window
-  const RangeFix = window.RangeFix;
-</script>
 ```
 
 Replace instances of `Range.prototype.getClientRects`/`getBoundingClientRect` with `RangeFix.getClientRects`/`getBoundingClientRect`:

--- a/README.md
+++ b/README.md
@@ -7,9 +7,39 @@ In particular:
 * A regression in Chrome 55 where images get no rectangle when they are wrapped in a node and you select across them.
 * A bug in IE (<=10) which results in scaled rectangles when using the browser's zoom feature.
 
+Install
+=======
+
+```bash
+$ npm install rangefix
+```
+
 Usage
 =====
-Include the rangefix.js library in your project.
+
+**CommonJS**
+
+```javascript
+const RangeFix = require('rangefix');
+```
+
+**AMD**
+
+```javascript
+define(['rangefix'], function(Rangefix) {
+  // ...
+});
+```
+
+**Browser global**
+
+```html
+<script src="path/to/rangefix.js"></script>
+<script>
+  // RangeFix will be available on window
+  const RangeFix = window.RangeFix;
+</script>
+```
 
 Replace instances of `Range.prototype.getClientRects`/`getBoundingClientRect` with `RangeFix.getClientRects`/`getBoundingClientRect`:
 

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
 		"type": "git",
 		"url": "https://github.com/edg2s/rangefix"
 	},
+	"main": "rangefix.js",
 	"scripts": {
 		"test": "grunt test"
 	},

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "rangefix",
-	"version": "0.2.4",
+	"version": "0.2.5",
 	"description": "Workaround for browser bugs in Range.prototype.getClientRects and Range.prototype.getBoundingClientRect.",
 	"license": "MIT",
 	"author": "Ed Sanders",

--- a/rangefix.js
+++ b/rangefix.js
@@ -1,5 +1,5 @@
 /*!
- * RangeFix v0.2.4
+ * RangeFix v0.2.5
  * https://github.com/edg2s/rangefix
  *
  * Copyright 2014-17 Ed Sanders.


### PR DESCRIPTION
This change adds `rangefix.js` as the `main` module in `package.json`. It allows us to require the `RangeFix` object directly, rather than specifying the path to the module

**Before**
```js
const RangeFix = require('rangefix/rangefix')
```

**After**
```js
const RangeFix = require('rangefix')
```

I have also added some more detailed installation and usage instructions to the README, specifically the three methods by which the `RangeFix` module can be made accessible to the application code.

Let me know if you have any suggestions